### PR TITLE
feat: Create basic framework for 2D model component

### DIFF
--- a/common/config_parser.py
+++ b/common/config_parser.py
@@ -97,6 +97,10 @@ class ConfigParser:
 
         elif comp_type_str == "HydraulicModel2D":
             mesh_file_path = os.path.join(self.config_dir, comp_params.pop('mesh_file'))
+            # The DEM file is used for setting elevation, which can be done
+            # after mesh creation. For now, we just pop it from the params.
+            comp_params.pop('dem_file', None) # Safely remove dem_file if it exists
+
             if not os.path.exists(mesh_file_path):
                 raise FileNotFoundError(f"Mesh file not found: {mesh_file_path}")
 

--- a/gui/main.py
+++ b/gui/main.py
@@ -190,6 +190,18 @@ def simulation_thread_logic(q, gui_data):
         for status in controller.run(num_steps, dt, global_inputs, monitored_components=monitored_components_by_name, data_queue=q):
             eel.update_status(status)
 
+        # --- After simulation, collect results from all components ---
+        print("--- Collecting final results from components ---")
+        for name, component in controller.components.items():
+            if hasattr(component, 'get_results'):
+                try:
+                    controller.results[name] = component.get_results()
+                    print(f"Collected results for component: {name}")
+                except Exception as e:
+                    print(f"Could not get results for component {name}: {e}")
+
+        last_run_controller.results = controller.results
+
         eel.simulation_finished({"message": "Simulation completed successfully!"})
     except Exception as e:
         print(f"An error occurred during simulation: {e}")

--- a/gui/web/app.js
+++ b/gui/web/app.js
@@ -182,9 +182,45 @@ document.addEventListener('DOMContentLoaded', () => {
         eel.get_results()().then(results => {
             if (results) {
                 simulationResults = results;
-                renderPlottingControls();
+                renderPlottingControls(); // For 1D plots
+                render2DResults(results); // For 2D map view
             }
         });
+    }
+
+    function render2DResults(results) {
+        const mapContentEl = document.getElementById('map-content');
+        if (!mapContentEl) return;
+
+        let htmlContent = '';
+        let found2D = false;
+
+        for (const compName in results) {
+            // Find the corresponding node in the data store to check its type
+            const nodeId = Object.keys(nodeDataStore).find(id => nodeDataStore[id].name === compName);
+            if (nodeId && nodeDataStore[nodeId].type === 'HydraulicModel2D') {
+                found2D = true;
+                // Format the results for display. Using JSON.stringify for a simple text view.
+                // The 'h' (water depth) array is often the most interesting. We'll show the last timestep.
+                const last_h = results[compName].h.slice(-1)[0];
+                const resultSummary = {
+                    component: compName,
+                    timesteps: results[compName].h.length,
+                    num_points: results[compName].points.length,
+                    num_triangles: results[compName].triangles.length,
+                    final_water_depth_sample: last_h.slice(0, 10) // Show a sample of the last water depth array
+                };
+
+                htmlContent += `<h4>Results for ${compName}</h4>`;
+                htmlContent += `<pre>${JSON.stringify(resultSummary, null, 2)}</pre>`;
+            }
+        }
+
+        if (found2D) {
+            mapContentEl.innerHTML = htmlContent;
+        } else {
+            mapContentEl.textContent = 'No 2D model results found in this simulation run.';
+        }
     }
 
     // --- Main UI Functions ---
@@ -539,7 +575,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function createConnection(sourceNode, targetNode) { connections.push({ from: sourceNode.id, to: targetNode.id }); const line = document.createElementNS('http://www.w3.org/2000/svg', 'line'); const sourceRect = sourceNode.getBoundingClientRect(); const targetRect = targetNode.getBoundingClientRect(); const canvasRect = canvas.getBoundingClientRect(); const x1 = sourceRect.left + sourceRect.width / 2 - canvasRect.left; const y1 = sourceRect.top + sourceRect.height / 2 - canvasRect.top; const x2 = targetRect.left + targetRect.width / 2 - canvasRect.left; const y2 = targetRect.top + targetRect.height / 2 - canvasRect.top; line.setAttribute('x1', x1); line.setAttribute('y1', y1); line.setAttribute('x2', x2); line.setAttribute('y2', y2); line.setAttribute('stroke', 'black'); line.setAttribute('stroke-width', '2'); line.setAttribute('marker-end', 'url(#arrowhead)'); svg.appendChild(line); }
     function renderProperties(nodeId) { propertiesContent.innerHTML = ''; plottingControls.style.display = 'none'; propertiesContent.style.display = 'block'; if (!nodeId) { propertiesContent.innerHTML = '<p>Select a component to see its properties.</p>'; return; } const nodeData = nodeDataStore[nodeId]; propertiesContent.appendChild(createPropertyInput('Name', 'name', nodeData, 'text')); for (const key in nodeData.params) { propertiesContent.appendChild(createPropertyInput(key, key, nodeData.params, 'number')); } }
     function clearSelection() { if (selectedNode) selectedNode.classList.remove('selected'); if (sourceNodeForConnection) sourceNodeForConnection.classList.remove('selected-source'); selectedNode = null; sourceNodeForConnection = null; renderProperties(null); if (simulationResults) { renderPlottingControls(); } }
-    function getDefaultParams(type) { switch(type) { case 'RiverReach': return { slope: 0.001, manning_n: 0.03, length: 1000, width: 20 }; case 'Catchment': return { CN: 75 }; case 'Gate': return { opening_height: 1.0, width: 10, C_d: 0.6 }; case 'Pump': return { a: -0.05, b: 0, c: 5.0 }; case 'Junction': return {}; default: return {}; } }
+    function getDefaultParams(type) { switch(type) { case 'RiverReach': return { slope: 0.001, manning_n: 0.03, length: 1000, width: 20 }; case 'Catchment': return { CN: 75 }; case 'Gate': return { opening_height: 1.0, width: 10, C_d: 0.6 }; case 'Pump': return { a: -0.05, b: 0, c: 5.0 }; case 'Junction': return {}; case 'HydraulicModel2D': return { mesh_file: 'channel_mesh.json', dem_file: 'gis_data/dem.tif' }; default: return {}; } }
     function createPropertyInput(label, key, dataObject, type) { const row = document.createElement('div'); row.className = 'property-row'; const labelEl = document.createElement('label'); labelEl.textContent = label.replace(/_/g, ' '); const inputEl = document.createElement('input'); inputEl.type = type; inputEl.value = dataObject[key]; inputEl.addEventListener('change', (e) => { dataObject[key] = (type === 'number') ? parseFloat(e.target.value) : e.target.value; if (key === 'name') document.getElementById(dataObject.id).textContent = e.target.value; }); row.appendChild(labelEl); row.appendChild(inputEl); return row; }
     function setupArrowheadMarker() { const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs'); const marker = document.createElementNS('http://www.w3.org/2000/svg', 'marker'); marker.setAttribute('id', 'arrowhead'); marker.setAttribute('viewBox', '0 0 10 10'); marker.setAttribute('refX', '8'); marker.setAttribute('refY', '5'); marker.setAttribute('markerWidth', '6'); marker.setAttribute('markerHeight', '6'); marker.setAttribute('orient', 'auto-start-reverse'); const path = document.createElementNS('http://www.w3.org/2000/svg', 'path'); path.setAttribute('d', 'M 0 0 L 10 5 L 0 10 z'); marker.appendChild(path); defs.appendChild(marker); svg.appendChild(defs); }
 

--- a/gui/web/index.html
+++ b/gui/web/index.html
@@ -31,6 +31,9 @@
             <div class="component-item" draggable="true" data-type="Pump">
                 ポンプ Pump
             </div>
+            <div class="component-item" draggable="true" data-type="HydraulicModel2D">
+                🌐 2D Model Area
+            </div>
 
             <!-- Data Registry & Preprocessing Pane -->
             <div id="data-pane">
@@ -133,6 +136,7 @@
         <div class="tab-nav">
             <button class="tab-button active" data-tab="time-series-pane">Time Series</button>
             <button class="tab-button" data-tab="profile-pane">1D Profile</button>
+            <button class="tab-button" data-tab="map-pane">2D Map</button>
             <button class="tab-button" data-tab="log-pane">Log</button>
         </div>
         <div class="tab-content">
@@ -143,6 +147,11 @@
             <!-- 1D Profile Chart Panel -->
             <div id="profile-pane" class="tab-pane">
                 <canvas id="profile-chart"></canvas>
+            </div>
+            <!-- 2D Map Panel (Placeholder) -->
+            <div id="map-pane" class="tab-pane">
+                <h4>2D Model Results</h4>
+                <pre id="map-content" style="white-space: pre-wrap; font-family: monospace; background-color: #f0f0f0; border: 1px solid #ccc; padding: 10px; height: 200px; overflow: auto;">Run a simulation with a 2D model to see results here.</pre>
             </div>
             <!-- Log Viewer Panel -->
             <div id="log-pane" class="tab-pane">

--- a/tests/test_gui_integration.py
+++ b/tests/test_gui_integration.py
@@ -10,6 +10,8 @@ from gui.main import _generate_config_dict
 from common.config_parser import ConfigParser
 from preissmann_model.model import HydraulicModel
 from preissmann_model.structures import Weir
+from model_2d.model import Model2D
+
 
 class TestGuiIntegration(unittest.TestCase):
 
@@ -85,6 +87,43 @@ class TestGuiIntegration(unittest.TestCase):
         self.assertIsInstance(weir_structure, Weir)
         self.assertEqual(weir_structure.name, "UpstreamWeir")
         print("Simulation build with nested components test passed.")
+
+    def test_2d_model_creation_from_gui(self):
+        """Test if a 2D model component can be created from GUI data."""
+        print("\nRunning test_2d_model_creation_from_gui...")
+
+        # Add a 2D model to the mock data
+        self.mock_gui_data["nodes"]["node-3"] = {
+            "id": "node-3",
+            "name": "2DFloodplain",
+            "type": "HydraulicModel2D",
+            "params": {
+                "mesh_file": "channel_mesh.json", # Using an existing file for the test
+                "dem_file": "gis_data/dem.tif"
+            }
+        }
+        self.mock_gui_data["connections"].append({"from": "node-1", "to": "node-3"})
+
+        config_dict = _generate_config_dict(self.mock_gui_data)
+
+        # Verify the config dictionary has the 2D model as a top-level component
+        self.assertEqual(len(config_dict["components"]), 2)
+        component_names = [c['name'] for c in config_dict['components']]
+        self.assertIn("2DFloodplain", component_names)
+
+        # Verify the simulation can be built
+        # Note: This requires the dummy mesh/dem files to exist at the specified paths
+        parser = ConfigParser(config_dict, base_path='.')
+        controller, _, _ = parser.build_simulation()
+
+        self.assertIn("2DFloodplain", controller.components)
+        model_2d_comp = controller.components["2DFloodplain"]
+
+        self.assertIsInstance(model_2d_comp, Model2D)
+
+        # Verify connection
+        self.assertIn("2DFloodplain", controller.network["MyRiver"])
+        print("2D model creation from GUI data test passed.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adds a new "2D Model Area" component to the GUI palette, allowing users to drag it onto the canvas.

Integrates the existing `Model2D` backend with the GUI by updating the `ConfigParser` and frontend Javascript. Adds a "2D Map" tab to the results area, which currently acts as a placeholder to display a summary of the 2D model's results.

Fixes a bug where final simulation results were not being collected by the controller, enabling post-simulation plotting for all components.

Adds a new integration test to verify that the 2D model component can be created and connected through the GUI data flow.