### PR TITLE
feat: Add dynamic 2D mesh generation from GUI

### DIFF
--- a/gui/main.py
+++ b/gui/main.py
@@ -4,6 +4,7 @@ Main Python script for the Eel-based GUI.
 import eel
 import yaml
 import csv
+import json
 import numpy as np
 import easygui
 import queue
@@ -44,10 +45,22 @@ def _generate_config_dict(gui_data):
         is_structure = node_data["type"] in ["Gate", "Pump", "Weir"]
 
         if not is_structure:
+            # Make a copy of params to avoid modifying the original GUI data
+            params = node_data["params"].copy()
+
+            # For 2D models, check if a mesh has been generated dynamically
+            if node_data["type"] == "HydraulicModel2D":
+                if params.get("generated_mesh_file"):
+                    # Use the generated mesh file for the simulation
+                    params["mesh_file"] = params["generated_mesh_file"]
+                else:
+                    # This case should be handled by the UI, but as a fallback:
+                    print("Warning: HydraulicModel2D is missing a generated mesh file. Simulation may fail.")
+
             component_config = {
                 "name": node_data["name"],
                 "type": node_data["type"],
-                "parameters": node_data["params"]
+                "parameters": params
             }
             # Ensure structures list exists for hydraulic models
             if node_data["type"] == "HydraulicModel":
@@ -237,6 +250,8 @@ def get_results():
 import os
 import pandas as pd
 import matplotlib.pyplot as plt
+from scipy.spatial import Delaunay
+from collections import defaultdict
 from preprocessing.baseflow_separation import lyne_hollick_filter
 
 @eel.expose
@@ -302,6 +317,49 @@ def open_file_dialog():
         # In a real app, you might return a specific error message
         # or handle it more gracefully. For now, we return None.
         return None
+
+@eel.expose
+def generate_mesh_from_params(params):
+    """
+    Generates a 2D mesh from parameters and saves it to a temporary file.
+    """
+    try:
+        print(f"Generating mesh with params: {params}")
+
+        # Ensure temp directory exists
+        temp_dir = 'temp'
+        if not os.path.exists(temp_dir):
+            os.makedirs(temp_dir)
+
+        output_path = os.path.join(temp_dir, params['output_filename'])
+
+        # --- Logic adapted from utils/create_channel_mesh.py ---
+        length = params.get('length', 1000)
+        width = params.get('width', 100)
+        num_x = params.get('num_x', 21)
+        num_y = params.get('num_y', 11)
+
+        x = np.linspace(0, length, num_x)
+        y = np.linspace(0, width, num_y)
+        xv, yv = np.meshgrid(x, y)
+        points = np.vstack([xv.ravel(), yv.ravel()]).T
+
+        tri = Delaunay(points)
+        triangles = tri.simplices
+
+        mesh_data = {
+            "points": points.tolist(),
+            "triangles": triangles.tolist()
+        }
+        with open(output_path, 'w') as f:
+            json.dump(mesh_data, f, indent=4)
+
+        print(f"Mesh saved to: {output_path}")
+        return {"mesh_path": output_path}
+
+    except Exception as e:
+        print(f"Error during mesh generation: {e}")
+        return {"error": str(e)}
 
 
 def main():

--- a/gui/web/app.js
+++ b/gui/web/app.js
@@ -398,8 +398,56 @@ document.addEventListener('DOMContentLoaded', () => {
         // Render other parameters
         for (const key in nodeData.params) {
             // Don't create a standard input for the one we just handled
-            if (key === 'rainfall_source') continue;
-            propertiesContent.appendChild(createPropertyInput(key, key, nodeData.params, 'number'));
+            if (key === 'rainfall_source' || key === 'generated_mesh_file') continue;
+
+            // For dem_file, use a text input instead of a number
+            const inputType = (key === 'dem_file') ? 'text' : 'number';
+            propertiesContent.appendChild(createPropertyInput(key, key, nodeData.params, inputType));
+        }
+
+        // Special UI for HydraulicModel2D for mesh generation
+        if (nodeData.type === 'HydraulicModel2D') {
+            const genButton = document.createElement('button');
+            genButton.textContent = 'Generate Mesh';
+            genButton.className = 'generate-button'; // For styling
+            genButton.addEventListener('click', () => {
+                // Call backend service to generate the mesh
+                const meshParams = {
+                    length: nodeData.params.length,
+                    width: nodeData.params.width,
+                    num_x: nodeData.params.num_x,
+                    num_y: nodeData.params.num_y,
+                    // We'll also pass the component name to create a unique filename
+                    output_filename: `${nodeData.name}_mesh.json`
+                };
+
+                // Show some feedback to the user
+                genButton.textContent = 'Generating...';
+                genButton.disabled = true;
+
+                eel.generate_mesh_from_params(meshParams)().then(result => {
+                    genButton.textContent = 'Generate Mesh';
+                    genButton.disabled = false;
+                    if (result.error) {
+                        alert(`Error generating mesh: ${result.error}`);
+                    } else {
+                        // Update the node's internal state with the path to the new mesh
+                        nodeData.params.generated_mesh_file = result.mesh_path;
+                        alert(`Mesh generated and saved to: ${result.mesh_path}`);
+                        // Optionally, re-render properties to show the new path if we had a field for it
+                        renderProperties(nodeId);
+                    }
+                });
+            });
+            propertiesContent.appendChild(genButton);
+
+            // Display the path to the generated mesh file if it exists
+            if (nodeData.params.generated_mesh_file) {
+                 const pathDisplay = document.createElement('div');
+                 pathDisplay.className = 'property-row-info';
+                 pathDisplay.textContent = `Generated Mesh: ${nodeData.params.generated_mesh_file}`;
+                 propertiesContent.appendChild(pathDisplay);
+            }
         }
     }
     function clearSelection() { /* ... implementation ... */ }
@@ -575,7 +623,7 @@ document.addEventListener('DOMContentLoaded', () => {
     function createConnection(sourceNode, targetNode) { connections.push({ from: sourceNode.id, to: targetNode.id }); const line = document.createElementNS('http://www.w3.org/2000/svg', 'line'); const sourceRect = sourceNode.getBoundingClientRect(); const targetRect = targetNode.getBoundingClientRect(); const canvasRect = canvas.getBoundingClientRect(); const x1 = sourceRect.left + sourceRect.width / 2 - canvasRect.left; const y1 = sourceRect.top + sourceRect.height / 2 - canvasRect.top; const x2 = targetRect.left + targetRect.width / 2 - canvasRect.left; const y2 = targetRect.top + targetRect.height / 2 - canvasRect.top; line.setAttribute('x1', x1); line.setAttribute('y1', y1); line.setAttribute('x2', x2); line.setAttribute('y2', y2); line.setAttribute('stroke', 'black'); line.setAttribute('stroke-width', '2'); line.setAttribute('marker-end', 'url(#arrowhead)'); svg.appendChild(line); }
     function renderProperties(nodeId) { propertiesContent.innerHTML = ''; plottingControls.style.display = 'none'; propertiesContent.style.display = 'block'; if (!nodeId) { propertiesContent.innerHTML = '<p>Select a component to see its properties.</p>'; return; } const nodeData = nodeDataStore[nodeId]; propertiesContent.appendChild(createPropertyInput('Name', 'name', nodeData, 'text')); for (const key in nodeData.params) { propertiesContent.appendChild(createPropertyInput(key, key, nodeData.params, 'number')); } }
     function clearSelection() { if (selectedNode) selectedNode.classList.remove('selected'); if (sourceNodeForConnection) sourceNodeForConnection.classList.remove('selected-source'); selectedNode = null; sourceNodeForConnection = null; renderProperties(null); if (simulationResults) { renderPlottingControls(); } }
-    function getDefaultParams(type) { switch(type) { case 'RiverReach': return { slope: 0.001, manning_n: 0.03, length: 1000, width: 20 }; case 'Catchment': return { CN: 75 }; case 'Gate': return { opening_height: 1.0, width: 10, C_d: 0.6 }; case 'Pump': return { a: -0.05, b: 0, c: 5.0 }; case 'Junction': return {}; case 'HydraulicModel2D': return { mesh_file: 'channel_mesh.json', dem_file: 'gis_data/dem.tif' }; default: return {}; } }
+    function getDefaultParams(type) { switch(type) { case 'RiverReach': return { slope: 0.001, manning_n: 0.03, length: 1000, width: 20 }; case 'Catchment': return { CN: 75 }; case 'Gate': return { opening_height: 1.0, width: 10, C_d: 0.6 }; case 'Pump': return { a: -0.05, b: 0, c: 5.0 }; case 'Junction': return {}; case 'HydraulicModel2D': return { length: 1000, width: 100, num_x: 21, num_y: 11, dem_file: 'gis_data/dem.tif', generated_mesh_file: '' }; default: return {}; } }
     function createPropertyInput(label, key, dataObject, type) { const row = document.createElement('div'); row.className = 'property-row'; const labelEl = document.createElement('label'); labelEl.textContent = label.replace(/_/g, ' '); const inputEl = document.createElement('input'); inputEl.type = type; inputEl.value = dataObject[key]; inputEl.addEventListener('change', (e) => { dataObject[key] = (type === 'number') ? parseFloat(e.target.value) : e.target.value; if (key === 'name') document.getElementById(dataObject.id).textContent = e.target.value; }); row.appendChild(labelEl); row.appendChild(inputEl); return row; }
     function setupArrowheadMarker() { const defs = document.createElementNS('http://www.w3.org/2000/svg', 'defs'); const marker = document.createElementNS('http://www.w3.org/2000/svg', 'marker'); marker.setAttribute('id', 'arrowhead'); marker.setAttribute('viewBox', '0 0 10 10'); marker.setAttribute('refX', '8'); marker.setAttribute('refY', '5'); marker.setAttribute('markerWidth', '6'); marker.setAttribute('markerHeight', '6'); marker.setAttribute('orient', 'auto-start-reverse'); const path = document.createElementNS('http://www.w3.org/2000/svg', 'path'); path.setAttribute('d', 'M 0 0 L 10 5 L 0 10 z'); marker.appendChild(path); defs.appendChild(marker); svg.appendChild(defs); }
 

--- a/model_2d/mesh.py
+++ b/model_2d/mesh.py
@@ -7,6 +7,7 @@ triangular mesh, including building the mesh topology from points and faces.
 """
 import numpy as np
 from collections import defaultdict
+import rasterio
 
 class Node:
     """Represents a vertex in the mesh."""
@@ -114,3 +115,31 @@ class Mesh:
                 self.boundary_edges['wall'].append(edge)
 
         print(f"Mesh built successfully: {len(self.nodes)} nodes, {len(self.faces)} faces, {len(self.edges)} edges.")
+
+    def set_bed_elevation_from_dem(self, dem_path: str):
+        """
+        Sets the z_bed attribute for each face by sampling a DEM raster.
+
+        Args:
+            dem_path (str): The file path to the DEM raster (e.g., GeoTIFF).
+        """
+        print(f"Sampling bed elevation from DEM: {dem_path}")
+        try:
+            with rasterio.open(dem_path) as dem:
+                # 1. Collect all face centroid coordinates
+                coords = [face.centroid for face in self.faces]
+
+                # 2. Sample the raster at all centroid locations
+                # The 'sample' method returns a generator
+                elevations = [val[0] for val in dem.sample(coords)]
+
+                # 3. Assign the sampled elevations to the faces
+                for face, elev in zip(self.faces, elevations):
+                    face.z_bed = float(elev)
+
+                print(f"Successfully set bed elevation for {len(self.faces)} faces.")
+
+        except Exception as e:
+            print(f"Error reading DEM or sampling elevations: {e}")
+            # Optionally, re-raise the exception if this is a critical failure
+            raise

--- a/tests/test_gui_integration.py
+++ b/tests/test_gui_integration.py
@@ -1,6 +1,7 @@
 import unittest
 import sys
 import os
+import shutil
 import numpy as np
 
 # Adjust path to import from the root of the project
@@ -124,6 +125,39 @@ class TestGuiIntegration(unittest.TestCase):
         # Verify connection
         self.assertIn("2DFloodplain", controller.network["MyRiver"])
         print("2D model creation from GUI data test passed.")
+
+    def test_mesh_generation_service(self):
+        """Test the mesh generation service."""
+        print("\nRunning test_mesh_generation_service...")
+        from gui.main import generate_mesh_from_params
+        import json
+
+        params = {
+            'length': 10, 'width': 5, 'num_x': 4, 'num_y': 3,
+            'output_filename': 'test_mesh.json'
+        }
+
+        result = generate_mesh_from_params(params)
+
+        self.assertIn('mesh_path', result)
+        self.assertIsNone(result.get('error'))
+
+        mesh_path = result['mesh_path']
+        self.assertTrue(os.path.exists(mesh_path))
+
+        with open(mesh_path, 'r') as f:
+            data = json.load(f)
+
+        self.assertIn('points', data)
+        self.assertIn('triangles', data)
+        self.assertEqual(len(data['points']), 12) # 4 * 3
+
+        # Clean up
+        temp_dir = 'temp'
+        if os.path.exists(temp_dir):
+            shutil.rmtree(temp_dir)
+
+        print("Mesh generation service test passed.")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implements dynamic mesh generation for 2D model components directly from the GUI.

- Replaces the static `mesh_file` property with parameters for `length`, `width`, and grid resolution.
- Adds a "Generate Mesh" button to the properties pane, which calls a new backend service to create the mesh file on the fly and save it to a temporary directory.
- Extends the `Mesh` class with a `set_bed_elevation_from_dem` method to sample elevation data from a DEM file.
- Adds a new integration test for the mesh generation service.