### PR TITLE
Refactor data processing services into a separate module

### DIFF
--- a/gui/main.py
+++ b/gui/main.py
@@ -11,6 +11,7 @@ import queue
 import threading
 from common.config_parser import ConfigParser
 from .config_generator import generate_config_from_gui_data
+from services.data_processing import run_preprocessing_preview, generate_mesh_from_params
 
 # --- Backend State Management ---
 class SimulationState:
@@ -28,6 +29,10 @@ sim_state = SimulationState()
 
 # Initialize Eel, specifying the web folder
 eel.init('web')
+
+# Expose the data processing services to the frontend
+eel.expose(run_preprocessing_preview, 'run_preprocessing_preview')
+eel.expose(generate_mesh_from_params, 'generate_mesh_from_params')
 
 
 @eel.expose
@@ -209,62 +214,6 @@ def get_results():
     return serializable_results
 
 
-import os
-import pandas as pd
-import matplotlib.pyplot as plt
-from scipy.spatial import Delaunay
-from collections import defaultdict
-from preprocessing.baseflow_separation import lyne_hollick_filter
-
-@eel.expose
-def run_preprocessing_preview(config):
-    """
-    Runs a preprocessing step and generates a preview plot.
-    """
-    print(f"Received preprocessing preview request with config: {config}")
-    try:
-        # For now, we only handle baseflow separation
-        if 'baseflow' in config:
-            bs_conf = config['baseflow']
-            flow_file = bs_conf['flow_data_path']
-            alpha = bs_conf['alpha']
-
-            # Assume file path is relative to project root
-            if not os.path.exists(flow_file):
-                return {"error": f"Data file not found: {flow_file}"}
-
-            flow_series = pd.read_csv(flow_file, index_col=0, parse_dates=True).iloc[:, 0]
-
-            # Run the separation
-            separated_df = lyne_hollick_filter(flow_series, alpha=alpha)
-
-            # Generate the plot
-            fig, ax = plt.subplots(figsize=(8, 4))
-            ax.plot(separated_df.index, separated_df['total_flow'], label='Total Flow', color='k')
-            ax.plot(separated_df.index, separated_df['baseflow'], label='Baseflow', color='b', linestyle='--')
-            ax.fill_between(separated_df.index, separated_df['baseflow'], separated_df['total_flow'], color='lightblue', alpha=0.6)
-            ax.legend()
-            ax.grid(True)
-            ax.set_title("Baseflow Separation Preview")
-            ax.set_xlabel("Date")
-            ax.set_ylabel("Discharge")
-            plt.tight_layout()
-
-            # Save plot to a temporary file in the web directory
-            # Use a timestamp to avoid browser caching issues
-            plot_filename = f"preview_plot_{pd.Timestamp.now().strftime('%Y%m%d%H%M%S')}.png"
-            plot_path = os.path.join('web', plot_filename)
-            plt.savefig(plot_path)
-            plt.close(fig)
-
-            print(f"Generated preview plot: {plot_path}")
-            return {"plot_path": plot_filename} # Return relative path for the web folder
-
-    except Exception as e:
-        print(f"An error occurred during preprocessing preview: {e}")
-        return {"error": str(e)}
-
-
 @eel.expose
 def open_file_dialog():
     """
@@ -280,48 +229,6 @@ def open_file_dialog():
         # or handle it more gracefully. For now, we return None.
         return None
 
-@eel.expose
-def generate_mesh_from_params(params):
-    """
-    Generates a 2D mesh from parameters and saves it to a temporary file.
-    """
-    try:
-        print(f"Generating mesh with params: {params}")
-
-        # Ensure temp directory exists
-        temp_dir = 'temp'
-        if not os.path.exists(temp_dir):
-            os.makedirs(temp_dir)
-
-        output_path = os.path.join(temp_dir, params['output_filename'])
-
-        # --- Logic adapted from utils/create_channel_mesh.py ---
-        length = params.get('length', 1000)
-        width = params.get('width', 100)
-        num_x = params.get('num_x', 21)
-        num_y = params.get('num_y', 11)
-
-        x = np.linspace(0, length, num_x)
-        y = np.linspace(0, width, num_y)
-        xv, yv = np.meshgrid(x, y)
-        points = np.vstack([xv.ravel(), yv.ravel()]).T
-
-        tri = Delaunay(points)
-        triangles = tri.simplices
-
-        mesh_data = {
-            "points": points.tolist(),
-            "triangles": triangles.tolist()
-        }
-        with open(output_path, 'w') as f:
-            json.dump(mesh_data, f, indent=4)
-
-        print(f"Mesh saved to: {output_path}")
-        return {"mesh_path": output_path}
-
-    except Exception as e:
-        print(f"Error during mesh generation: {e}")
-        return {"error": str(e)}
 
 
 def main():

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the 'services' directory a Python package.

--- a/services/data_processing.py
+++ b/services/data_processing.py
@@ -1,0 +1,100 @@
+"""
+This module contains backend services for data processing tasks,
+such as running preprocessing steps or generating mesh files.
+"""
+import os
+import json
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+from scipy.spatial import Delaunay
+from preprocessing.baseflow_separation import lyne_hollick_filter
+
+def run_preprocessing_preview(config):
+    """
+    Runs a preprocessing step and generates a preview plot.
+    """
+    print(f"Received preprocessing preview request with config: {config}")
+    try:
+        # For now, we only handle baseflow separation
+        if 'baseflow' in config:
+            bs_conf = config['baseflow']
+            flow_file = bs_conf['flow_data_path']
+            alpha = bs_conf['alpha']
+
+            # Assume file path is relative to project root
+            if not os.path.exists(flow_file):
+                return {"error": f"Data file not found: {flow_file}"}
+
+            flow_series = pd.read_csv(flow_file, index_col=0, parse_dates=True).iloc[:, 0]
+
+            # Run the separation
+            separated_df = lyne_hollick_filter(flow_series, alpha=alpha)
+
+            # Generate the plot
+            fig, ax = plt.subplots(figsize=(8, 4))
+            ax.plot(separated_df.index, separated_df['total_flow'], label='Total Flow', color='k')
+            ax.plot(separated_df.index, separated_df['baseflow'], label='Baseflow', color='b', linestyle='--')
+            ax.fill_between(separated_df.index, separated_df['baseflow'], separated_df['total_flow'], color='lightblue', alpha=0.6)
+            ax.legend()
+            ax.grid(True)
+            ax.set_title("Baseflow Separation Preview")
+            ax.set_xlabel("Date")
+            ax.set_ylabel("Discharge")
+            plt.tight_layout()
+
+            # Save plot to a temporary file in the web directory
+            # Use a timestamp to avoid browser caching issues
+            plot_filename = f"preview_plot_{pd.Timestamp.now().strftime('%Y%m%d%H%M%S')}.png"
+            plot_path = os.path.join('web', plot_filename)
+            plt.savefig(plot_path)
+            plt.close(fig)
+
+            print(f"Generated preview plot: {plot_path}")
+            return {"plot_path": plot_filename} # Return relative path for the web folder
+
+    except Exception as e:
+        print(f"An error occurred during preprocessing preview: {e}")
+        return {"error": str(e)}
+
+def generate_mesh_from_params(params):
+    """
+    Generates a 2D mesh from parameters and saves it to a temporary file.
+    """
+    try:
+        print(f"Generating mesh with params: {params}")
+
+        # Ensure temp directory exists
+        temp_dir = 'temp'
+        if not os.path.exists(temp_dir):
+            os.makedirs(temp_dir)
+
+        output_path = os.path.join(temp_dir, params['output_filename'])
+
+        # --- Logic adapted from utils/create_channel_mesh.py ---
+        length = params.get('length', 1000)
+        width = params.get('width', 100)
+        num_x = params.get('num_x', 21)
+        num_y = params.get('num_y', 11)
+
+        x = np.linspace(0, length, num_x)
+        y = np.linspace(0, width, num_y)
+        xv, yv = np.meshgrid(x, y)
+        points = np.vstack([xv.ravel(), yv.ravel()]).T
+
+        tri = Delaunay(points)
+        triangles = tri.simplices
+
+        mesh_data = {
+            "points": points.tolist(),
+            "triangles": triangles.tolist()
+        }
+        with open(output_path, 'w') as f:
+            json.dump(mesh_data, f, indent=4)
+
+        print(f"Mesh saved to: {output_path}")
+        return {"mesh_path": output_path}
+
+    except Exception as e:
+        print(f"Error during mesh generation: {e}")
+        return {"error": str(e)}

--- a/tests/test_gui_integration.py
+++ b/tests/test_gui_integration.py
@@ -129,7 +129,7 @@ class TestGuiIntegration(unittest.TestCase):
     def test_mesh_generation_service(self):
         """Test the mesh generation service."""
         print("\nRunning test_mesh_generation_service...")
-        from gui.main import generate_mesh_from_params
+        from services.data_processing import generate_mesh_from_params
         import json
 
         params = {


### PR DESCRIPTION
This commit improves the structure and modularity of the codebase by extracting data processing services from `gui/main.py` into their own dedicated module.

The following changes are included:

- **New Services Module:**
  - A new `services/` directory and `services/data_processing.py` file have been created.
  - The `services` directory has been made a Python package.

- **Move Service Functions:**
  - The `run_preprocessing_preview` and `generate_mesh_from_params` functions have been moved from `gui/main.py` to `services/data_processing.py`.

- **Update Imports:**
  - `gui/main.py` has been updated to import and expose the service functions from their new location.
  - `tests/test_gui_integration.py` has been updated to import from the new module.

This refactoring makes the responsibilities of `gui/main.py` clearer and improves the overall modularity of the backend code.